### PR TITLE
Initial implementation of Kafka Connect docker image build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,54 @@
+name: Docker
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "[0-9].[0-9]+.[0-9]+*"
+  # pull_request:
+env:
+  PLATFORMS: linux/amd64
+jobs:
+  docker:
+    name: Docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.ref }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Determine tag or commit
+        uses: haya14busa/action-cond@v1
+        id: refortag
+        with:
+          cond: ${{ startsWith(github.ref, 'refs/tags/') }}
+          if_true: ${{ github.ref }}
+          if_false: latest
+      - name: Determine image tag
+        id: imagetag
+        run: echo "::set-output name=value::${TAG_OR_BRANCH##*/}"
+        env:
+          TAG_OR_BRANCH: ${{ steps.refortag.outputs.value }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      - name: Build Kafka Connect
+        uses: docker/build-push-action@v2
+        with:
+          tags: ghcr.io/banzaicloud/kafka-connect:${{ steps.imagetag.outputs.value }}
+          file: Dockerfile
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+ARG CP_KAFKA_CONNECT_BASE_VERSION=6.0.1
+
+FROM confluentinc/cp-kafka-connect-base:$CP_KAFKA_CONNECT_BASE_VERSION
+
+ENV COMPONENT=kafka-connect
+
+ARG CONFLUENTINC_JDBC_CONNECTOR_VERSION=10.0.1
+ARG CONFLUENTINC_HDFS_CONNECTOR_VERSION=10.0.0
+ARG CONFLUENTINC_ELASTICSEARCH_CONNECTOR_VERSION=11.0.0
+ARG CONFLUENTINC_S3_CONNECTOR_VERSION=5.5.3
+ARG CONFLUENTINC_AVRO_CONVERTER_CONNECTOR_VERSION=5.5.3
+
+RUN confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:$CONFLUENTINC_JDBC_CONNECTOR_VERSION \
+    && confluent-hub install --no-prompt confluentinc/kafka-connect-hdfs:$CONFLUENTINC_HDFS_CONNECTOR_VERSION \
+    && confluent-hub install --no-prompt confluentinc/kafka-connect-elasticsearch:$CONFLUENTINC_ELASTICSEARCH_CONNECTOR_VERSION \
+    && confluent-hub install --no-prompt confluentinc/kafka-connect-s3:$CONFLUENTINC_S3_CONNECTOR_VERSION \
+    && confluent-hub install --no-prompt confluentinc/kafka-connect-avro-converter:$CONFLUENTINC_AVRO_CONVERTER_CONNECTOR_VERSION

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Kafka Connect Docker Image
+
+Docker file for building docker image for [Kafka Connect](https://kafka.apache.org/documentation/#connect) bundled with a couple of free connectors from [Confluent Hub](https://www.confluent.io/hub/).
+
+The following connectors from [Confluent Hub](https://www.confluent.io/hub/) are bundled into the docker image:
+
+- JDBC Connect (Source and Sink)
+- Kafka Connect HDFS
+- Kafka Connect Elasticsearch
+- Amazon S3 Sink Connector
+- Kafka Connect Avro Converter

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,10 @@
+#!/bin/bash -xe
+
+. ./hooks/env
+
+docker build \
+    --build-arg "SOURCE_REF=$GIT_SHA1" \
+    --build-arg "DOCKERFILE_PATH=$DOCKERFILE_PATH" \
+    --build-arg "SOURCE_TYPE=$SOURCE_TYPE" \
+    ${VERSION:+--build-arg "VERSION=$VERSION"} \
+    -t $IMAGE_NAME $DOCKERFILE_PATH

--- a/hooks/env
+++ b/hooks/env
@@ -1,0 +1,14 @@
+# These values are passed by the hub, but if they aren't we can get them from git.
+[ -n "$SOURCE_BRANCH" ]  || SOURCE_BRANCH=${CIRCLE_TAG}
+[ -n "$SOURCE_BRANCH" ]  || SOURCE_BRANCH=$(git symbolic-ref -q --short HEAD | tr '/' '-')
+[ -n "$SOURCE_BRANCH" ]  || SOURCE_BRANCH=latest
+[ -n "$GIT_SHA1" ] || GIT_SHA1=$(git rev-parse -q HEAD)
+
+[[ "${SOURCE_BRANCH:0:1}" =~ [0-9] ]] && VERSION=${SOURCE_BRANCH/-*/}
+
+[ "$SOURCE_BRANCH" = "master" ] && SOURCE_BRANCH="latest"
+
+# Set defaults for build arguments
+[ -n "$SOURCE_TYPE" ]        || SOURCE_TYPE=git
+[ -n "$DOCKERFILE_PATH" ]    || DOCKERFILE_PATH=.
+[ -n "$IMAGE_NAME" ]         || IMAGE_NAME=pdouble16/kafka-connect:$SOURCE_BRANCH


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Build Kafka Connect  docker image based on Confluents docker image version `6.0.0` with open source free connectors (that were present in version `5.5.x` included.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Starting from version `6.0.0` the docker image provided by Confluent doesn't include free connectors.

